### PR TITLE
add dockerfile with multistage build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM golang:1.22.3 AS builder
+WORKDIR /src
+COPY *.go go.mod go.sum tracker.db ./
+RUN go mod download && \
+    go mod tidy && \
+    CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o app
+
+
+FROM alpine:latest
+
+WORKDIR /app
+
+COPY --from=builder /src/app /src/tracker.db /app/
+
+ENTRYPOINT ["./app"]
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,23 @@
 FROM golang:1.22.3 AS builder
+
 WORKDIR /src
-COPY *.go go.mod go.sum tracker.db ./
+
+COPY *.go go.mod go.sum ./
+
+ENV CGO_ENABLED=0 GOOS=linux GOARCH=amd64
+
 RUN go mod download && \
     go mod tidy && \
-    CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o app
+    go build -o app
 
 
 FROM alpine:latest
 
 WORKDIR /app
 
-COPY --from=builder /src/app /src/tracker.db /app/
+COPY tracker.db ./
+
+COPY  --from=builder /src/app /app/
 
 ENTRYPOINT ["./app"]
 


### PR DESCRIPTION
Использование multistage сборок позволяет значительно сократить размер docker image, конкретно этот экземпляр получился 16MB